### PR TITLE
Uncomment default transit-json-reader

### DIFF
--- a/src/lambdaisland/fetch.cljs
+++ b/src/lambdaisland/fetch.cljs
@@ -76,7 +76,7 @@
 
 (defmethod decode-body :transit-json [_ bodyp opts]
   (p/let [text (j/call bodyp :text)]
-    (transit/read (:transit-json-reader opts #_@transit-json-reader) text)))
+    (transit/read (:transit-json-reader opts @transit-json-reader) text)))
 
 (defmethod decode-body :json [_ bodyp opts]
   (p/let [body bodyp]


### PR DESCRIPTION
I think it was accidentally commented in ff090791049ed792def4e787c26697406896ab9b thus breaking the transit decoding when not providing a reader via `opts`.