### PR TITLE
Update to use latest orb and Clojure version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  kaocha: lambdaisland/kaocha@dev:first
-  clojure: lambdaisland/clojure@dev:first
+  kaocha: lambdaisland/kaocha@0.0.1
+  clojure: lambdaisland/clojure@0.0.5
 
 commands:
   checkout_and_run:
@@ -22,7 +22,7 @@ commands:
 jobs:
   java-11-clojure-1_10:
     executor: clojure/openjdk11
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   java-11-clojure-1_9:
     executor: clojure/openjdk11
@@ -30,7 +30,7 @@ jobs:
 
   java-9-clojure-1_10:
     executor: clojure/openjdk9
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   java-9-clojure-1_9:
     executor: clojure/openjdk9
@@ -38,7 +38,7 @@ jobs:
 
   java-8-clojure-1_10:
     executor: clojure/openjdk8
-    steps: [{checkout_and_run: {clojure_version: "1.10.0-RC5"}}]
+    steps: [{checkout_and_run: {clojure_version: "1.10.3"}}]
 
   java-8-clojure-1_9:
     executor: clojure/openjdk8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,19 @@ commands:
         type: string
     steps:
       - checkout
+     # - clojure/with_cache:
+     #     cache_version: << parameters.clojure_version >>
+     #     steps:
+     #       - kaocha/execute:
+     #           args: "--reporter documentation --plugin cloverage --codecov"
+     #           clojure_version: << parameters.clojure_version >>
       - clojure/with_cache:
           cache_version: << parameters.clojure_version >>
           steps:
             - kaocha/execute:
-                args: "--reporter documentation --plugin cloverage --codecov"
+                args: "--reporter documentation"
                 clojure_version: << parameters.clojure_version >>
-      - kaocha/upload_codecov
+     #- kaocha/upload_codecov
 
 jobs:
   java-11-clojure-1_10:


### PR DESCRIPTION
Use the latest version of our Clojure orb, and replace the RC version with the latest one.
