### PR TITLE
Add example code to README as suggested by issue 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ A more typical ClojureScript example
     (prn :error e)))
 ```
 
+An example of using fetch at the REPL
+```clojure
+
+(p/let [res (fetch ...)]
+  (def res res))
+```
+After that you have your response map in `res` and you can inspect it to see what is in there.
+
 - Simply uses promises (add [kitchen-async](https://github.com/athos/kitchen-async) if you like it sweeter)
 - Returns a promise which delivers something akin to a ring response map
 - Does basic content negotiation and encoding/decoding of request/response body

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ ClojureScript wrapper around the JavaScript fetch API.
    :body #js {...}}>
 ```
 
+A more typical ClojureScript example
+```clojure
+(ns fetch.demo.core
+  (:require [kitchen-async.promise :as p]
+            [lambdaisland.fetch :as fetch]))
+
+(p/try
+  (p/let [resp (fetch/get
+                "https://api.github.com/users/seisvelas/gists"
+                {:accept :json
+                 :content-type :json})]
+    (prn (:body resp)))
+  (p/catch :default e
+     ;; log your exception here
+    (prn :error e)))
+```
+
 - Simply uses promises (add [kitchen-async](https://github.com/athos/kitchen-async) if you like it sweeter)
 - Returns a promise which delivers something akin to a ring response map
 - Does basic content negotiation and encoding/decoding of request/response body


### PR DESCRIPTION
This is an example I put [here](https://stackoverflow.com/questions/58665259).

The fetch's default is using `transit+json`, which is good for typical ClojureScript + Clojure web application. However, in real world case, there are a lot of APIs using `json`. 

I saw [this issue](https://github.com/lambdaisland/fetch/issues/5), and then thought would it be a good idea to add it on the README?
