### PR TITLE
add :signal as opts key

### DIFF
--- a/src/lambdaisland/fetch.cljs
+++ b/src/lambdaisland/fetch.cljs
@@ -67,7 +67,7 @@
   (j/call response :json))
 
 (defn fetch-opts [{:keys [method accept content-type
-                          headers redirect mode cache
+                          headers redirect mode cache signal
                           credentials referrer-policy]
                    :or   {method          :get
                           accept          :transit-json
@@ -86,6 +86,7 @@
          :redirect        (name redirect)
          :mode            (name mode)
          :cache           (name cache)
+         :signal          signal
          :credentials     (name credentials)
          :referrer-policy (name referrer-policy)}))
 


### PR DESCRIPTION
I added the missing `:signal` key as requested in https://github.com/lambdaisland/fetch/issues/21.

This allows me to abort an ongoing fetch by doing this:

```clojure
(def controller (new js/AbortController))
(fetch/get url {:signal (.-signal controller})
(.abort controller)
```